### PR TITLE
Make express read the X-Forwarded-For headers

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -23,7 +23,7 @@ const apiLimiter = new RateLimit({
     expiry: 1, // 2 seconds
   }),
   // windowMs: 1000, // 1 second (redis uses expiry, not windowMs, see https://github.com/wyattjoh/rate-limit-redis/issues/32 )
-  max: 2, // limit each IP to 3 requests per windowMs or expiry
+  max: 1, // limit each IP to 3 requests per windowMs or expiry
   statusCode: 429,
   // message: 'Rate limit exceeded. Please wait',
   // keyGenerator: (req) => {
@@ -33,6 +33,7 @@ const apiLimiter = new RateLimit({
 });
 
 app.use(cors());
+app.set("trust proxy", true);
 app.use(apiLimiter);
 app.use(express.static(__dirname));
 app.use(bodyParser.json());


### PR DESCRIPTION
So express needs to trust the proxy it resides behind in order for it to populate the `req.ip` field. If we don't trust the proxy all requests will be received with the local IP of the proxy which is `10.0.0.2` in our docker network.

https://expressjs.com/en/guide/behind-proxies.html

Like this guide explains, when setting `app.set("tust proxy", true)` the following will happen

> If `true`, the client’s IP address is understood as the left-most entry in the `X-Forwarded-For` header.

Then

> The `req.ip` and `req.ips` values are populated with the list of addresses from X-Forwarded-For.

The reason this dind't work for **tinderfest** was because we needed to make some networking changes for `traefik`. You can see these changes in the webkom infra repo.

```sh
esas_stream.1.2juhbh86oe8n@esas-production    |   'sec-fetch-site': 'cross-site',
esas_stream.1.2juhbh86oe8n@esas-production    |   'x-forwarded-for': '129.241.231.203',
esas_stream.1.2juhbh86oe8n@esas-production    |   'x-forwarded-host': 'stream.abakus.no',
esas_stream.1.2juhbh86oe8n@esas-production    |   'x-forwarded-port': '443',
esas_stream.1.2juhbh86oe8n@esas-production    |   'x-forwarded-proto': 'https',
esas_stream.1.2juhbh86oe8n@esas-production    |   'x-forwarded-server': 'bcb817bdb3de',
esas_stream.1.2juhbh86oe8n@esas-production    |   'x-real-ip': '129.241.231.203'
```